### PR TITLE
Ajout d'un fichier de configuration local.local.cfg pour l'environnement d'éxécution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ nb-configuration.xml
 
 # Ignore a local.cfg file in root folder, if it exists
 /local.cfg
-# Also ignore it under dspace/config
-/dspace/config/local.cfg
+# UdeMChange: we ignore local.local.cfg, but we put local.cfg in the repo
+/dspace/config/local.local.cfg
 
 ##Mac noise
 .DS_Store

--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -1,0 +1,63 @@
+#####################################
+# Configuration locale pour Calypso #
+#####################################
+
+# Les propriétés définies ici ont priorité sur celles définies
+# dans les autres fichiers de configuration (dspace.cfg, modules/*.cfg, ...).
+# Toutefois, les variables d'environnement ont priorités sur ce fichier.
+# Voir config-definition.xml pour plus de détails.
+
+# Dans le fichier local.cfg, on doit définir UNIQUEMENT LES PROPRIÉTÉS
+# QUI ONT LA MÊME VALEUR POUR TOUTES LES INSTANCES DE CALYPSO. Ce sont
+# donc des propriétés qui sont liées au fonctionnement de l'application
+# et non son environnement d'excutation.
+
+# Par exemple, on va mettre ici des propriétés de configuration du "browsing"
+# mais pas celles liées à l'accès à la base de donnée (URL de connexion,
+# usager et mot de passe, etc.)
+
+# Les propriétés spécifiques à l'environnement d'exécution seront définies
+# dans des fichiers local.local.cfg qui est inclus avec la
+# directive suivante:
+
+include = local.local.cfg
+
+# Les propriétés définies dans local.local.cfg ont priorités sur celles
+# définies ci-dessous, si jamais elles sont le même nom. Donc le fichier
+# local.local.cfg pourrait aussi servir à redéféfinir localement des 
+# propriétés liées au fonctionnement, mais cette pratique devrait être
+# réservée à des fins de test.
+
+# Tous nos changements aux propriétés de configuration doivent être dans
+# local.cfg ou dans local.local.cfg (ou en variable d'environnement). 
+# JAMAIS dans dspace.cfg, modules/*.cfg, etc. Ces fichiers doivent toujours
+# être conformes à la dernière version de Dspace.
+
+##########################
+# Nom et langues du site #
+##########################
+
+# Nom du site
+dspace.name = Calypso   # Voir l'impact réel et déterminer le bon nom et s'il doit être local
+
+# Default language for metadata values
+default.language = fr                   # Ne semble pas très utilisé
+default.locale = fr                     # Semble nécessaire pour que submission-forms_fr.xml fonctionne
+webui.supported.locales = fr, en        # Bonne pratique de le spécifier ici. Doit être cohérent avec config.prod.yml "languages"
+
+
+##########
+# Browse #
+##########
+
+# Voir la section "Browse Configuration" dans dspace.cfg
+
+
+########
+# IIIF #
+########
+
+iiif.enabled = true         # Nécessaire et global
+event.dispatcher.default.consumers = versioning, discovery, eperson, iiif
+
+# Plusieurs autres configurations possibles, voir modules/iiif.cfg

--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -72,6 +72,7 @@ Common usage:
     <!-- Load the configurations -->
     <!-- In Ant, properties are immutable, so the first one "wins". In this case,
          we load the local.cfg FIRST, so that its settings are used by default. -->
+    <property file="config/local.local.cfg" /> <!-- Configuration de l'environnement d'exécution-->
     <property file="${local-config}" />
     <property file="${config}" />
     <property file="${irus-config}" />


### PR DESCRIPTION
J'ai séparé le fichier de configuration local.cfg en deux: local.cfg et local.local.cfg.

local.cfg devrait contenir des propriétés qui sont communes à tous les environnements d'exécution (poste personnel, serveur de dev, de prod, etc.). Ces propriétés sont surtout liées au fonctionnement de l'application, du service, etc.

local.local.cfg (pas dans le repo) devrait contenir des propriétés spécifiques à l'environnement, comme des adresses, des mots de passe, etc.

Malheureusement, il faut modifier légèrement les sources de DSpace, mais ça devrait être facile à maintenir:
- .gitignore: on n'ignore plus local.cfg, mais on ignore local.local.cfg
- build.xml: on doit ajouter explicitement la lecture de local.local.cfg car dans Ant le "include" ne fonctionne pas

Pour tester:
- créer un fichier local.local.cfg en s'inspirant de celui de Martin (dans Teams)
- mvn package
- ant fresh_install
- vérifier que ça démarre bien

Pour s'assurer que le fichier local.local.cfg est bien lu, on peut faire une erreur dans db.password, puis:
- mvn package
- ant test_database (ça devrait donner une erreur)
