### PR TITLE
Retrait du vocabulaire SRSC du browse

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -53,6 +53,12 @@ webui.supported.locales = fr, en
 
 # Voir la section "Browse Configuration" dans dspace.cfg
 
+webui.browse.index.1 = title:item:title:asc 
+webui.browse.index.2 = dateissued:item:dateissued:desc
+webui.browse.index.3 = author:metadata:dcterms.creator:text:asc
+webui.browse.index.4 = contributor:metadata:dcterms.contributor:text:asc
+webui.browse.index.5 = subject:metadata:dcterms.subject:text
+webui.browse.index.6 = titleindex:metadata:dcterms.title:asc
 
 ########
 # IIIF #

--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -52,6 +52,7 @@ webui.supported.locales = fr, en
 ##########
 
 # Voir la section "Browse Configuration" dans dspace.cfg
+# Configuration du browse avec dcterms
 
 webui.browse.index.1 = title:item:title:asc 
 webui.browse.index.2 = dateissued:item:dateissued:desc

--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -55,7 +55,8 @@ webui.supported.locales = fr, en
 # Configuration du browse avec dcterms
 
 
-
+# On retirer le browse du vaocabulaire SRSC, livré par défaut avec DSpace
+webui.browse.vocabularies.disabled = srsc
 
 ########
 # IIIF #

--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -52,7 +52,6 @@ webui.supported.locales = fr, en
 ##########
 
 # Voir la section "Browse Configuration" dans dspace.cfg
-# Configuration du browse avec dcterms
 
 webui.browse.index.1 = title:item:title:asc 
 webui.browse.index.2 = dateissued:item:dateissued:desc

--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -61,6 +61,9 @@ webui.browse.index.4 = contributor:metadata:dcterms.contributor:text:asc
 webui.browse.index.5 = subject:metadata:dcterms.subject:text
 webui.browse.index.6 = titleindex:metadata:dcterms.title:asc
 
+# On retirer le browse du vaocabulaire SRSC, livré par défaut avec DSpace
+webui.browse.vocabularies.disabled = srsc
+
 ########
 # IIIF #
 ########

--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -53,12 +53,6 @@ webui.supported.locales = fr, en
 
 # Voir la section "Browse Configuration" dans dspace.cfg
 
-webui.browse.index.1 = title:item:title:asc 
-webui.browse.index.2 = dateissued:item:dateissued:desc
-webui.browse.index.3 = author:metadata:dcterms.creator:text:asc
-webui.browse.index.4 = contributor:metadata:dcterms.contributor:text:asc
-webui.browse.index.5 = subject:metadata:dcterms.subject:text
-webui.browse.index.6 = titleindex:metadata:dcterms.title:asc
 
 # On retirer le browse du vaocabulaire SRSC, livré par défaut avec DSpace
 webui.browse.vocabularies.disabled = srsc


### PR DESCRIPTION
On veut retirer l'affichage du vocabulaire contrôlé SRSC (livré par défaut avec DSpace) du browse.

Pour tester, compiler le backend et redémarrer Tomcat, voir si l'index est bien retiré du menu "Tout DSpace".