### PR TITLE
Retrait du vocabulaire SRSC du browse

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -55,6 +55,9 @@ webui.supported.locales = fr, en
 # Configuration du browse avec dcterms
 
 
+# On retirer le browse du vaocabulaire SRSC, livré par défaut avec DSpace
+webui.browse.vocabularies.disabled = srsc
+
 ############################
 # Registre des métadonnées #
 ############################


### PR DESCRIPTION
Pour retirer l'affichage du vocabulaire contrôlé SRSC du Browse.

Pour tester, compiler et démarrer, voir si l'index est bien retiré du menu "Tout Calypso".