### PR TITLE
Ajout de la lecture du fichier local.local.cfg

### DIFF
--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -42,6 +42,7 @@
                             <files>
                                 <file>${root.basedir}/dspace/config/dspace.cfg</file>
                                 <file>${root.basedir}/dspace/config/local.cfg</file>
+                                <file>${root.basedir}/dspace/config/local.local.cfg</file>
                             </files>
                             <quiet>true</quiet>
                         </configuration>


### PR DESCRIPTION
Pour tester:
- mvn clean
- mvn package
- ant fresh_install

Le dossier dspace devrait être correct dans le fichier webapps/server/WEB-INF/classes/application.properties et Tomcat devrait pouvoir démarrer correctement.