### PR TITLE
Ajout d'un seeAlso à un item pour chaque fichier dans un bundle spécifiée en configuration

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -79,6 +79,9 @@ iiif.search.plugin = org.dspace.app.iiif.service.CalypsoWordHighlightSolrSearch
 iiif.rendering.bundle = RENDERING
 iiif.rendering.item = Notice complète
 
+# Pour ajouter des seeAlso à un item depuis un bundle spécifique
+iiif.seealso.bundle = SEEALSO
+
 # Pour ajouter du contenu OCR aux images
 iiif.ocr.bundle = OCR
 iiif.ocr.seealso.label = Contenu issu de l'OCR

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/model/generator/ManifestGenerator.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/model/generator/ManifestGenerator.java
@@ -1,0 +1,241 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif.model.generator;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+
+import de.digitalcollections.iiif.model.ImageContent;
+import de.digitalcollections.iiif.model.MetadataEntry;
+import de.digitalcollections.iiif.model.OtherContent;
+import de.digitalcollections.iiif.model.PropertyValue;
+import de.digitalcollections.iiif.model.enums.ViewingHint;
+import de.digitalcollections.iiif.model.search.ContentSearchService;
+import de.digitalcollections.iiif.model.sharedcanvas.Manifest;
+import de.digitalcollections.iiif.model.sharedcanvas.Range;
+import de.digitalcollections.iiif.model.sharedcanvas.Resource;
+import de.digitalcollections.iiif.model.sharedcanvas.Sequence;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * This generator wraps a domain model for the {@code Manifest}.
+ * <p>
+ * Please note that this is a request scoped bean. This mean that for each http request a
+ * different instance will be initialized by Spring and used to serve this specific request.</p>
+ * <p>
+ *  The Manifest is an overall description of the structure and properties of the digital representation
+ *  of an object. It carries information needed for the viewer to present the digitized content to the user,
+ *  such as a title and other descriptive information about the object or the intellectual work that
+ *  it conveys. Each manifest describes how to present a single object such as a book, a photograph,
+ *  or a statue.</p>
+ *
+ * Please note that this is a request scoped bean. This means that for each http request a
+ * different instance will be initialized by Spring and used to serve this specific request.
+ *
+ * @author Michael Spalti  mspalti@willamette.edu
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@RequestScope
+@Component
+public class ManifestGenerator implements IIIFResource {
+
+    private String identifier;
+    private String label;
+    private PropertyValue description;
+    private ImageContent logo;
+    private ViewingHint viewingHint;
+    private Sequence sequence;
+    private List<OtherContent> seeAlsos = new ArrayList<>();
+    private OtherContent related;
+    private ImageContent thumbnail;
+    private ContentSearchService searchService;
+    private List<OtherContent> renderings = new ArrayList<>();
+    private final List<URI> license = new ArrayList<>();
+    private final List<MetadataEntry> metadata = new ArrayList<>();
+    private final List<Range> ranges = new ArrayList<>();
+
+    /**
+     * Sets the mandatory manifest identifier.
+     * @param identifier manifest identifier
+     */
+    public void setIdentifier(@NotNull String identifier) {
+
+        if (identifier.isEmpty()) {
+            throw new RuntimeException("Invalid manifest identifier. Cannot be an empty string.");
+        }
+        this.identifier = identifier;
+    }
+
+    /**
+     * Sets the manifest label.
+     * @param label manifest label
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public void addLogo(ImageContentGenerator logo) {
+        this.logo = (ImageContent) logo.generateResource();
+    }
+
+    /**
+     * Sets the viewing hint. In IIIF Presentation API version 3.0 semantics this becomes the "behavior"
+     * @param viewingHint a viewing hint
+     */
+    public void addViewingHint(String viewingHint) {
+        BehaviorGenerator hint = new BehaviorGenerator().setType(viewingHint);
+        this.viewingHint = hint.generateValue();
+    }
+
+    /**
+     * Adds add single (mandatory) {@ode sequence} to the manifest. In IIIF Presentation API 3.0 "sequence"
+     * is replaced by "items"
+     * @param sequence canvas list model (sequence)
+     */
+    public void addSequence(CanvasItemsGenerator sequence) {
+        this.sequence = (Sequence) sequence.generateResource();
+    }
+
+    /**
+     * Adds an optional {@code seeAlso} element to Manifest.
+     * @param seeAlso other content model
+     */
+    public void addSeeAlso(ExternalLinksGenerator seeAlso) {
+        this.seeAlsos.add((OtherContent) seeAlso.generateResource());
+    }
+
+    /**
+     * Adds optional thumbnail image resource to manifest.
+     * @param thumbnail an image content generator
+     */
+    public void addThumbnail(ImageContentGenerator thumbnail) {
+        this.thumbnail = (ImageContent) thumbnail.generateResource();
+    }
+
+    /**
+     * Adds an optional {@code related} field to the manifest.
+     * @param related other content generator
+     */
+    public void addRelated(ExternalLinksGenerator related) {
+        this.related = (OtherContent) related.generateResource();
+    }
+
+    /**
+     * Adds optional search service to the manifest.
+     * @param searchService search service generator
+     */
+    public void addService(ContentSearchGenerator searchService) {
+        this.searchService = (ContentSearchService) searchService.generateService();
+    }
+
+    /**
+     * Adds a single metadata field to Manifest.
+     * @param field property field
+     * @param value property value
+     */
+    public void addMetadata(String field, String value, String... rest) {
+        MetadataEntryGenerator meg = new MetadataEntryGenerator().setField(field).setValue(value, rest);
+        metadata.add(meg.generateValue());
+    }
+
+    /**
+     * Adds an optional license to manifest.
+     * @param license license terms
+     */
+    public void addLicense(String license) {
+        this.license.add(URI.create(license));
+    }
+
+    /**
+     * Adds optional description to Manifest.
+     * @param value the description value
+     */
+    public void addDescription(String value) {
+        description = new PropertyValueGenerator().getPropertyValue(value).generateValue();
+    }
+
+    /**
+     * Adds optional Range to the manifest's structures element.
+     * @param rangeGenerator to add
+     */
+    public void addRange(RangeGenerator rangeGenerator) {
+        ranges.add((Range) rangeGenerator.generateResource());
+    }
+
+    /**
+     * Adds a rendering annotation to the Sequence. The rendering is a link to an external resource intended
+     * for display or download by a human user. This is typically going to be a PDF file.
+     * @param otherContent generator for the resource
+     */
+    public void addRendering(ExternalLinksGenerator otherContent) {
+        this.renderings.add((OtherContent) otherContent.generateResource());
+    }
+
+    @Override
+    public Resource<Manifest> generateResource() {
+
+        if (identifier == null) {
+            throw new RuntimeException("The Manifest resource requires an identifier.");
+        }
+        Manifest manifest;
+        if (label != null) {
+            manifest = new Manifest(identifier, label);
+        } else {
+            manifest = new Manifest(identifier);
+        }
+        if (renderings.size() > 0) {
+            manifest.setRenderings(renderings);
+        }
+        if (logo != null) {
+            List<ImageContent> logos = new ArrayList<>();
+            logos.add(logo);
+            manifest.setLogos(logos);
+        }
+        if (sequence != null) {
+            manifest.addSequence(sequence);
+        }
+        if (ranges.size() > 0) {
+            for (Range range : ranges) {
+                manifest.addRange(range);
+            }
+        }
+        if (metadata.size() > 0) {
+            for (MetadataEntry meta : metadata) {
+                manifest.addMetadata(meta);
+            }
+        }
+        if (seeAlsos != null) {
+            for (OtherContent sa : seeAlsos) {
+                manifest.addSeeAlso(sa);
+            }
+        }
+        if (related != null) {
+            manifest.addRelated(related);
+        }
+        if (searchService != null) {
+            manifest.addService(searchService);
+        }
+        if (license.size() > 0) {
+            manifest.setLicenses(license);
+        }
+        if (description != null) {
+            manifest.setDescription(description);
+        }
+        if (thumbnail != null) {
+            manifest.addThumbnail(thumbnail);
+        }
+        if (viewingHint != null) {
+            manifest.addViewingHint(viewingHint);
+        }
+        return manifest;
+    }
+
+}

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/ManifestService.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/ManifestService.java
@@ -145,7 +145,7 @@ public class ManifestService extends AbstractResourceService {
         manifestGenerator.addSequence(
                 sequenceService.getSequence(item));
         addRendering(item, context);
-        addSeeAlso(item);
+        addSeeAlso(item, context);
     }
 
     /**
@@ -263,14 +263,20 @@ public class ManifestService extends AbstractResourceService {
     }
 
     /**
-     * This method adds into the manifest a {@code seeAlso} reference to additional
+     * This method adds into the manifest one or more {@code seeAlso} reference to additional
      * resources found in the Item bundle(s). A typical use case would be METS / ALTO files
      * that describe the resource.
      *
      * @param item the DSpace Item.
+     * @param contest The DSpace context
      */
-    private void addSeeAlso(Item item) {
-        manifestGenerator.addSeeAlso(seeAlsoService.getSeeAlso(item));
+    private void addSeeAlso(Item item, Context context) {
+        // There may be more than one for this item
+        List<ExternalLinksGenerator> elgs = seeAlsoService.getSeeAlsos(item, context);
+        // We add the list of seeAlsos generated
+        for (ExternalLinksGenerator elg: elgs ) {
+            manifestGenerator.addSeeAlso(elg);
+        }
     }
 
     /**

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/SeeAlsoService.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/SeeAlsoService.java
@@ -1,0 +1,93 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif.service;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.app.iiif.model.generator.AnnotationGenerator;
+import org.dspace.app.iiif.model.generator.ExternalLinksGenerator;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * This service provides methods for creating {@code seAlso} external link. There should be a single instance of
+ * this service per request. The {@code @RequestScope} provides a single instance created and available during
+ * complete lifecycle of the HTTP request.
+ *
+ * @author Michael Spalti  mspalti@willamette.edu
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@RequestScope
+@Component
+public class SeeAlsoService extends AbstractResourceService {
+
+    private static final String SEE_ALSO_LABEL = "More descriptions of this resource";
+    protected String SEEALSO_BUNDLE_NAME;
+
+    public SeeAlsoService(ConfigurationService configurationService) {
+        setConfiguration(configurationService);
+        SEEALSO_BUNDLE_NAME = configurationService.getProperty("iiif.seealso.bundle");
+    }
+
+    /**
+     * Generates all the seeAlso links for the item. The seeAlso may be
+     * a reference to an annotation list (legacy method) or one per bitstream
+     * in a specific bundle.
+     * 
+     * @param item      The DSpace item
+     * @param context   The DSpace context
+     * @return          A list of seeAlsos, may be empty but not null
+     */
+    public List<ExternalLinksGenerator> getSeeAlsos(Item item, Context context) {
+
+        // The list to return
+        List<ExternalLinksGenerator> elgs = new ArrayList<ExternalLinksGenerator>();
+    
+        if (SEEALSO_BUNDLE_NAME != null) {
+            // New method: we add bitstreams from the specified bundle
+            List<Bundle> bundles = item.getBundles();
+            if ( bundles != null ) {
+                for (Bundle bundle : bundles) {
+                    if ( bundle.getName().equals(SEEALSO_BUNDLE_NAME) ) {
+                        List<Bitstream> bitstreams = bundle.getBitstreams();
+                        for (Bitstream bitstream : bitstreams) {
+                            String mimeType = null;
+                            try {
+                                mimeType = bitstream.getFormat(context).getMIMEType();
+                            } catch (SQLException e) {
+                                e.printStackTrace();
+                            }
+                            // We add the bitstream
+                            String id = BITSTREAM_PATH_PREFIX + "/" + bitstream.getID() + "/content";
+                            elgs.add(
+                                new ExternalLinksGenerator(id)
+                                    .setLabel(utils.getIIIFLabel(bitstream, bitstream.getName()))
+                                    .setFormat(mimeType)
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        else {
+            // Original method: return a link to an annotation list
+            elgs.add(new ExternalLinksGenerator(IIIF_ENDPOINT + item.getID() + "/manifest/seeAlso")
+            .setType(AnnotationGenerator.TYPE)
+            .setLabel(SEE_ALSO_LABEL));
+        }
+        return elgs;
+    }
+
+}


### PR DESCRIPTION
Le fichier local.cfg a été modifié, donc le comportement précédent n'est plus supporté, c'est-à-dire qu'on ne retrouve plus dans le manifest un seeAlso qui pointe vers une annotationList. Pour retrouver ce comportement, retirer la configuration iiif.seealso.bundle.

Maintenant, si cette configuration est active, les fichier dans un bundle "SEEALSO" seront insérés dans un seeAlso au niveau du manifest, donc de l'item.

Pour tester, ajouter un tel bundle avec un fichier dans un item et vérifier dans le manifest.