### PR TITLE
Ajout au manifest d'un lien vers une liste d'annotations pour les transcriptions

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -87,4 +87,8 @@ iiif.ocr.bundle = OCR
 iiif.ocr.seealso.label = Contenu issu de l'OCR
 iiif.ocr.seealso.profile = http://www.loc.gov/standards/alto/v3/alto.xsd
 
+# Pour ajouter des transcriptions aux images
+iiif.transcriptions.bundle = TRANSCRIPTIONS
+iiif.transcriptions.label = Transcriptions
+
 # Plusieurs autres configurations possibles, voir modules/iiif.cfg

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/IIIFController.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/IIIFController.java
@@ -1,0 +1,130 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif;
+
+import java.util.UUID;
+
+import org.dspace.app.iiif.service.utils.IIIFUtils;
+import org.dspace.core.Context;
+import org.dspace.web.ContextUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Controller for IIIF Presentation and Search API.
+ *
+ * @author Michael Spalti  mspalti@willamette.edu
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@RestController
+@RequestMapping("/iiif")
+// Only enable this controller if "iiif.enabled=true"
+@ConditionalOnProperty("iiif.enabled")
+public class IIIFController {
+
+    @Autowired
+    IIIFServiceFacade iiifFacade;
+
+    /**
+     * The manifest response contains sufficient information for the client to initialize
+     * itself and begin to display something quickly to the user. The manifest resource
+     * represents a single object and any intellectual work or works embodied within that
+     * object. In particular it includes the descriptive, rights and linking information
+     * for the object. It then embeds the sequence(s) of canvases that should be rendered
+     * to the user.
+     *
+     * Called with GET to retrieve the manifest for a single DSpace item.
+     *
+     * @param id DSpace Item uuid
+     * @return manifest as JSON
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/manifest", produces = "application/json")
+    public String findOne(@PathVariable UUID id) {
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        return iiifFacade.getManifest(context, id);
+    }
+
+    /**
+     * Any resource in the Presentation API may have a search service associated with it.
+     * The resource determines the scope of the content that will be searched. A service
+     * associated with a manifest will search all of the annotations on canvases or other
+     * objects below the manifest, a service associated with a particular range will only
+     * search the canvases within the range, or a service on a canvas will search only
+     * annotations on that particular canvas. The URIs for services associated with different
+     * resources must be different to allow the client to use the correct one for the desired
+     * scope of the search.
+     *
+     * This endpoint for searches within the manifest scope (by DSpace item uuid).
+     *
+     * @param id DSpace Item uuid
+     * @param query query terms
+     * @return AnnotationList as JSON
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/manifest/search", produces = "application/json")
+    public String searchInManifest(@PathVariable UUID id,
+                                   @RequestParam(name = "q") String query) {
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        return iiifFacade.searchInManifest(context, id, query);
+    }
+
+    /**
+     * All resources can link to semantic descriptions of themselves via the seeAlso property.
+     * These could be METS, ALTO, full text, or a schema.org descriptions.
+     *
+     * Since there's currently no reliable way to associate "seeAlso" links and individual
+     * canvases (e.g. associate a single image with its ALTO file) the
+     * scope is the entire manifest (or DSpace Item).
+     *
+     * @param id DSpace Item uuid
+     * @return AnnotationList as JSON
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/manifest/seeAlso", produces = "application/json")
+    public String findSeeAlsoList(@PathVariable UUID id) {
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        return iiifFacade.getSeeAlsoAnnotations(context, id);
+    }
+
+    /**
+     * The canvas represents an individual page or view and acts as a central point for
+     * laying out the different content resources that make up the display. This information
+     * should be embedded within a sequence.
+     *
+     * This endpoint allows canvases to be dereferenced separately from the manifest. This
+     * is an atypical use case.
+     *
+     * @param id DSpace Item uuid
+     * @param cid canvas identifier
+     * @return canvas as JSON
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/{id}/canvas/{cid}", produces = "application/json")
+    public String findCanvas(@PathVariable UUID id, @PathVariable String cid) {
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        return iiifFacade.getCanvas(context, id, cid);
+    }
+
+    /**
+     * Any bitstream may have transcriptions attached to it. This URL will return an
+     * annotationList for the bitstream, built with the files withing a specific bundle.
+     * 
+     * @param iId    The item UUID
+     * @param bId    The bitstream UUID
+     * @param cId    The canvas ID
+     * @return      An annotationList in JSON format. The list may be empty.
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/{iId}/{bId}/{cId}/transcriptions", produces = "application/json")
+    public String findTranscriptions(@PathVariable UUID iId, @PathVariable UUID bId, @PathVariable String cId) {
+        Context context = ContextUtil.obtainCurrentRequestContext();
+        return iiifFacade.getTranscriptions(context, iId, bId, cId, iId + "/" + bId + "/" + cId + "/transcriptions");
+    }
+}

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/IIIFServiceFacade.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/IIIFServiceFacade.java
@@ -1,0 +1,151 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import org.dspace.app.iiif.service.AnnotationListService;
+import org.dspace.app.iiif.service.CanvasLookupService;
+import org.dspace.app.iiif.service.ManifestService;
+import org.dspace.app.iiif.service.SearchService;
+import org.dspace.app.iiif.service.utils.IIIFUtils;
+import org.dspace.content.Item;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+/**
+ * IIIF Service facade to support IIIF Presentation and Search API requests.
+ *
+ * @author Michael Spalti  mspalti@willamette.edu
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@Service
+public class IIIFServiceFacade {
+
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    BitstreamService bitstreamService;
+
+    @Autowired
+    ManifestService manifestService;
+
+    @Autowired
+    SearchService searchService;
+
+    @Autowired
+    AnnotationListService annotationListService;
+
+    @Autowired
+    CanvasLookupService canvasLookupService;
+
+    @Autowired
+    IIIFUtils utils;
+
+    /**
+     * The manifest response contains sufficient information for the client to initialize itself
+     * and begin to display something quickly to the user. The manifest resource represents a single
+     * object and any intellectual work or works embodied within that object. In particular it
+     * includes the descriptive, rights and linking information for the object. It then embeds
+     * the sequence(s) of canvases that should be rendered to the user.
+     *
+     * Returns manifest for single DSpace item.
+     *
+     * @param id DSpace Item uuid
+     * @return manifest as JSON
+     */
+    @Cacheable(key = "#id.toString()", cacheNames = "manifests")
+    @PreAuthorize("hasPermission(#id, 'ITEM', 'READ')")
+    public String getManifest(Context context, UUID id)
+            throws ResourceNotFoundException {
+        Item item;
+        try {
+            item = itemService.find(context, id);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        if (item == null || !utils.isIIIFEnabled(item)) {
+            throw new ResourceNotFoundException("IIIF manifest for  id " + id + " not found");
+        }
+        return manifestService.getManifest(item, context);
+    }
+
+    /**
+     * The canvas represents an individual page or view and acts as a central point for
+     * laying out the different content resources that make up the display. This information
+     * should be embedded within a sequence.
+     *
+     * @param id DSpace item uuid
+     * @param canvasId canvas identifier
+     * @return canvas as JSON
+     */
+    @PreAuthorize("hasPermission(#id, 'ITEM', 'READ')")
+    public String getCanvas(Context context, UUID id, String canvasId)
+            throws ResourceNotFoundException {
+        Item item;
+        try {
+            item = itemService.find(context, id);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        if (item == null) {
+            throw new ResourceNotFoundException("IIIF canvas for  id " + id + " not found");
+        }
+        return canvasLookupService.generateCanvas(context, item, canvasId);
+    }
+
+    /**
+     * Returns search hits and word coordinates as an AnnotationList.
+     *
+     * Search scope is a single DSpace item or manifest.
+     *
+     * @param id DSpace item uuid
+     * @param query  query terms
+     * @return AnnotationList as JSON
+     */
+    @PreAuthorize("hasPermission(#id, 'ITEM', 'READ')")
+    public String searchInManifest(Context context, UUID id, String query) {
+
+        return searchService.searchWithinManifest(id, query);
+    }
+
+    /**
+     * Returns annotations for machine readable metadata that describes the resource.
+     *
+     * @param id the Item uuid
+     * @return AnnotationList as JSON
+     */
+    @PreAuthorize("hasPermission(#id, 'ITEM', 'READ')")
+    public String getSeeAlsoAnnotations(Context context, UUID id) {
+        return annotationListService.getSeeAlsoAnnotations(context, id);
+    }
+
+    /**
+     * Returns annotations for transcriptions of the bitstream.
+     *
+     * @param context           The DSpace context
+     * @param iId               The Item uuid
+     * @param bId               The Bitstream uuid
+     * @param cId               The Canvas id
+     * @param annotationListId  The ID of the annotation list itself (the part after the base IIIF service URL)
+     * @return AnnotationList as JSON
+     */
+    @PreAuthorize("hasPermission(#bId, 'BITSTREAM', 'READ')")
+    public String getTranscriptions(Context context, UUID iId, UUID bId, String cId, String annotationListId) {
+        return annotationListService.getTranscriptionsAnnotations(context, iId, bId, cId, annotationListId);
+    }
+
+}

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/model/generator/CanvasGenerator.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/model/generator/CanvasGenerator.java
@@ -14,6 +14,7 @@ import javax.validation.constraints.NotNull;
 import de.digitalcollections.iiif.model.ImageContent;
 import de.digitalcollections.iiif.model.MetadataEntry;
 import de.digitalcollections.iiif.model.OtherContent;
+import de.digitalcollections.iiif.model.sharedcanvas.AnnotationList;
 import de.digitalcollections.iiif.model.sharedcanvas.Canvas;
 import de.digitalcollections.iiif.model.sharedcanvas.Resource;
 
@@ -33,6 +34,7 @@ public class CanvasGenerator implements IIIFResource {
     private Integer width;
     private ImageContent thumbnail;
     private List<ExternalLinksGenerator> seeAlso = null;
+    private List<AnnotationList> otherContent = new ArrayList<AnnotationList>();
 
     /**
      * Constructor
@@ -105,6 +107,16 @@ public class CanvasGenerator implements IIIFResource {
     }
 
     /**
+     * Adds a link to transcriptions to the canvas.
+     * @param oc The othercontent link
+     * @return The object
+     */
+    public CanvasGenerator addTranscriptions(AnnotationList oc) {
+        if (oc != null) this.otherContent.add(oc);
+        return this;
+    }
+
+    /**
      * Adds single metadata field to Manifest.
      * @param field property field
      * @param value property value
@@ -155,6 +167,11 @@ public class CanvasGenerator implements IIIFResource {
         if (seeAlso != null && seeAlso.size() > 0) {
             for (ExternalLinksGenerator link: seeAlso) {
                 canvas.addSeeAlso((OtherContent)link.generateResource());
+            }
+        }
+        if (otherContent != null && otherContent.size() > 0) {
+            for (AnnotationList oc: otherContent) {
+                canvas.addOtherContent(oc);
             }
         }
         return canvas;

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/model/generator/ContentAsTextGenerator.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/model/generator/ContentAsTextGenerator.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif.model.generator;
+
+import de.digitalcollections.iiif.model.MimeType;
+import de.digitalcollections.iiif.model.openannotation.ContentAsText;
+import de.digitalcollections.iiif.model.sharedcanvas.Resource;
+
+import java.util.Locale;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * Generator for a text annotation.
+ */
+@Scope("prototype")
+@Component
+public class ContentAsTextGenerator implements IIIFResource {
+
+    private String text;
+    private String format;
+    private String type;
+    private String language;
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    @Override
+    public Resource<ContentAsText> generateResource() {
+        if (text == null) {
+            throw new RuntimeException("Missing required text for the text annotation.");
+        }
+        ContentAsText content = new ContentAsText(text);
+        if ( format != null ) content.setFormat(MimeType.fromTypename(format));
+        if ( type != null ) content.setType(type);
+        if ( language != null ) content.setLanguage(new Locale(language));
+        return content;
+    }
+}

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/AnnotationListService.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/AnnotationListService.java
@@ -1,0 +1,206 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.app.iiif.model.generator.AnnotationGenerator;
+import org.dspace.app.iiif.model.generator.AnnotationListGenerator;
+import org.dspace.app.iiif.model.generator.CanvasGenerator;
+import org.dspace.app.iiif.model.generator.ContentAsTextGenerator;
+import org.dspace.app.iiif.model.generator.ExternalLinksGenerator;
+import org.dspace.app.iiif.service.utils.IIIFUtils;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.core.Utils;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import de.digitalcollections.iiif.model.MimeType;
+import de.digitalcollections.iiif.model.openannotation.ContentAsText;
+
+/**
+ * This service provides methods for creating an {@code Annotation List}. There should be a single instance of
+ * this service per request. The {@code @RequestScope} provides a single instance created and available during
+ * complete lifecycle of the HTTP request.
+ *
+ * @author Michael Spalti  mspalti@willamette.edu
+ * @author Andrea Bollini (andrea.bollini at 4science.it)
+ */
+@RequestScope
+@Component
+public class AnnotationListService extends AbstractResourceService {
+
+
+    @Autowired
+    IIIFUtils utils;
+
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    BitstreamService bitstreamService;
+
+    @Autowired
+    BitstreamFormatService bitstreamFormatService;
+
+    @Autowired
+    AnnotationListGenerator annotationList;
+
+    private String TRANSCRIPTIONS_BUNDLE_NAME = null;
+
+    public AnnotationListService(ConfigurationService configurationService) {
+        setConfiguration(configurationService);
+        TRANSCRIPTIONS_BUNDLE_NAME = configurationService.getProperty("iiif.transcriptions.bundle");
+    }
+
+    /**
+     * Returns an AnnotationList for bitstreams in the OtherContent bundle.
+     * These resources are not appended directly to the manifest but can be accessed
+     * via the seeAlso link.
+     *
+     * The semantics of this linking property may be extended to full text files, but
+     * machine readable formats like ALTO, METS, and schema.org descriptions are preferred.
+     *
+     * @param context DSpace context
+     * @param id bitstream uuid
+     * @return AnnotationList as JSON
+     */
+    public String getSeeAlsoAnnotations(Context context, UUID id)
+            throws RuntimeException {
+
+        // We need the DSpace item to proceed
+        Item item;
+        try {
+            item = itemService.find(context, id);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        // AnnotationList requires an identifier.
+        annotationList.setIdentifier(IIIF_ENDPOINT + id + "/manifest/seeAlso");
+
+        // Get the "seeAlso" bitstreams for the item. Add
+        // Annotations for each bitstream found.
+        List<Bitstream> bitstreams = utils.getSeeAlsoBitstreams(item);
+        for (Bitstream bitstream : bitstreams) {
+            BitstreamFormat format;
+            String mimetype;
+            try {
+                format = bitstream.getFormat(context);
+                mimetype = format.getMIMEType();
+            } catch (SQLException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+            AnnotationGenerator annotation = new AnnotationGenerator(IIIF_ENDPOINT + bitstream.getID())
+                .setMotivation(AnnotationGenerator.LINKING)
+                .setResource(getLinksGenerator(mimetype, bitstream));
+            annotationList.addResource(annotation);
+        }
+        return utils.asJson(annotationList.generateResource());
+    }
+
+    /**
+     * Find transcriptions for the bitstream and return an annotationList with the content
+     * of these transcriptions.
+     * 
+     * @param context           The DSpace context
+     * @param iId               The Item UUID
+     * @param bId               The Bitstream UUID
+     * @param cId               The canvas ID
+     * @param annotationListId  The ID of the annotation list itself (the part after the base IIIF service URL)
+     * @return
+     */
+    public String getTranscriptionsAnnotations(Context context, UUID iId, UUID bId, String cId, String annotationListId) {
+
+        // Set the ID for the annotationList
+        annotationList.setIdentifier(IIIF_ENDPOINT + annotationListId);
+
+        // First get the DSpace object
+        try {
+            Bitstream bts = bitstreamService.find(context, bId);
+            if (bts != null) {
+                // Get the item (assume first bundle and first item)
+                List<Bundle> bundles = bts.getBundles();
+                if (bundles.size() > 0) {
+                    Bundle bdl = bundles.get(0);
+                    List<Item> items = bdl.getItems();
+                    if (items.size() >0) {
+                        // We have the item, try to find the required bundle
+                        Item item = items.get(0);
+                        List<Bundle> itemBundles = item.getBundles();
+                        for (Bundle itemBundle: itemBundles) {
+                            if (itemBundle.getName().equals(TRANSCRIPTIONS_BUNDLE_NAME)) {
+                                // We have the required bundle, let's look at the bitstreams
+                                String rootName = IIIFUtils.getRootName(bts.getName());
+                                String canvasId = IIIF_ENDPOINT + iId + "/canvas/" + cId;
+                                List<Bitstream> tBitstreams = itemBundle.getBitstreams();
+                                for ( Bitstream tBitstream: tBitstreams ) {
+                                    // The name must begin with the name of the bitstream
+                                    if (IIIFUtils.getRootName(tBitstream.getName()).startsWith(rootName)) {
+                                        // The format must be HTML or plain text or JSON
+                                        BitstreamFormat format = tBitstream.getFormat(context);
+                                        if ( format.getMIMEType().equals("text/plain") || format.getMIMEType().equals("text/html") ) {
+                                            AnnotationGenerator annotation = new AnnotationGenerator(IIIF_ENDPOINT + tBitstream.getID())
+                                            .setMotivation(AnnotationGenerator.PAINTING)
+                                            .setOnCanvas(new CanvasGenerator(canvasId))
+                                            .setResource(getContentGenerator(context, tBitstream, format.getMIMEType()));
+                                            annotationList.addResource(annotation);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            // If there is an exception, simply return en empty annotationList.
+        }
+
+        // We will return the annotationList in JSON
+        return utils.asJson(annotationList.generateResource());
+    }
+
+    private ExternalLinksGenerator getLinksGenerator(String mimetype, Bitstream bitstream) {
+        String identifier = BITSTREAM_PATH_PREFIX
+                + "/"
+                + bitstream.getID()
+                + "/content";
+
+        return new ExternalLinksGenerator(identifier)
+                .setFormat(mimetype)
+                .setLabel(bitstream.getName());
+    }
+
+    private ContentAsTextGenerator getContentGenerator(Context context, Bitstream bts, String mimetype) {
+        ContentAsTextGenerator generator = new ContentAsTextGenerator();
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            Utils.copy(bitstreamService.retrieve(context, bts), bos);
+            generator.setText(bos.toString());
+            generator.setFormat(mimetype);
+        }
+        catch (IOException | SQLException | AuthorizeException e) {
+            // Logging?
+        }
+        return generator;
+    }
+}

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/CanvasSeeAlsoService.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/CanvasSeeAlsoService.java
@@ -6,8 +6,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.ArrayList;
 
-import org.dspace.app.iiif.model.generator.AnnotationGenerator;
 import org.dspace.app.iiif.model.generator.ExternalLinksGenerator;
+import org.dspace.app.iiif.service.utils.IIIFUtils;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
@@ -84,14 +84,13 @@ public class CanvasSeeAlsoService extends AbstractResourceService {
         if ( seeAlsoBundle == null ) return links;
 
         // Check if we have a bitstream with a correct name
-        String name = getRootName(bitstream.getName());
+        String name = IIIFUtils.getRootName(bitstream.getName());
         List<Bitstream> bts = seeAlsoBundle.getBitstreams();
         for ( Bitstream bt: bts ) {
-            if ( name.equals(getRootName(bt.getName()))) {
+            if ( name.equals(IIIFUtils.getRootName(bt.getName()))) {
                 try {
                     links.add(new ExternalLinksGenerator(BITSTREAM_PATH_PREFIX + "/" + bt.getID() + "/content")
                             .setFormat(bt.getFormat(context).getMIMEType())
-//                            .setType(AnnotationGenerator.TYPE)
                             .setLabel(SEEALSO_LABEL)
                             .setProfile(SEEALSO_PROFILE));
                 }
@@ -100,19 +99,4 @@ public class CanvasSeeAlsoService extends AbstractResourceService {
         }
         return links;
     }
-
-    /**
-     * Check a String (filename) and returns the portion before the last occurrence of "."
-     * @param name  The String to check
-     * @return  The portion before ".", or the string itself if not found
-     */
-    private String getRootName(String name) {
-        String root = name;
-        int dotPos = root.lastIndexOf(".");
-        if (dotPos > 0) {
-            root = name.substring(0, dotPos);
-        }
-        return root;
-    }
-
 }

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/CanvasService.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/CanvasService.java
@@ -34,6 +34,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
+import de.digitalcollections.iiif.model.sharedcanvas.AnnotationList;
+
 /**
  * This service provides methods for creating {@code Canvases}. There should be a single instance of
  * this service per request. The {@code @RequestScope} provides a single instance created and available during
@@ -53,6 +55,9 @@ public class CanvasService extends AbstractResourceService {
 
     @Autowired
     CanvasSeeAlsoService canvasSeeAlsoService;
+
+    @Autowired
+    CanvasTranscriptionsService canvasTranscriptionsService;
 
     @Autowired
     IIIFUtils utils;
@@ -199,11 +204,12 @@ public class CanvasService extends AbstractResourceService {
                 thumbUtil.getThumbnailProfile(), THUMBNAIL_PATH);
 
         List<ExternalLinksGenerator> canvasSeeAlso = canvasSeeAlsoService.getCanvasSeeAlso(context, item, bitstream);
+        AnnotationList canvasTranscriptions = canvasTranscriptionsService.getCanvasTranscriptions(context, item, bitstream, IIIF_ENDPOINT + manifestId + "/" + bitstreamId + "/c" + count + "/transcriptions");
 
         return addMetadata(context, bitstream,
                 new CanvasGenerator(IIIF_ENDPOINT + manifestId + "/canvas/c" + count)
                     .addImage(image.generateResource()).addThumbnail(thumb.generateResource()).setHeight(canvasHeight)
-                    .setWidth(canvasWidth).setLabel(label).addSeeAlso(canvasSeeAlso));
+                    .setWidth(canvasWidth).setLabel(label).addSeeAlso(canvasSeeAlso)).addTranscriptions(canvasTranscriptions);
     }
 
     /**

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/CanvasTranscriptionsService.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/CanvasTranscriptionsService.java
@@ -1,0 +1,99 @@
+package org.dspace.app.iiif.service;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.dspace.app.iiif.model.generator.AnnotationGenerator;
+import org.dspace.app.iiif.model.generator.ExternalLinksGenerator;
+import org.dspace.app.iiif.service.utils.IIIFUtils;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import de.digitalcollections.iiif.model.PropertyValue;
+import de.digitalcollections.iiif.model.sharedcanvas.AnnotationList;
+
+/**
+ * This service creates a list of seeAlso links for a canvas (image = bitstream).
+ * 
+ * A link will be created for every bitstream in a specified bundle
+ * (iiif.ocr.bundle) with a name that begins with the same name as the bundle
+ * (minus the file extension). Configuration properties iiif.ocr.seealso.label
+ * and iiif.ocr.seealso.profiles must also be set.
+ */
+@RequestScope
+@Component
+public class CanvasTranscriptionsService extends AbstractResourceService {
+
+    private boolean addTranscriptions = false; 
+    private String TRANSCRIPTIONS_BUNDLE_NAME = null;
+    private String TRANSCRIPTIONS_LABEL = null;
+
+    /**
+     * Creates a service with the appropriate configuration.
+     * 
+     * @param configurationService  DSpace configuration service
+     */
+    public CanvasTranscriptionsService(ConfigurationService configurationService) {
+        setConfiguration(configurationService);
+
+        // Check if we generate a link to transcriptions for canvas
+        TRANSCRIPTIONS_BUNDLE_NAME = configurationService.getProperty("iiif.transcriptions.bundle");
+        TRANSCRIPTIONS_LABEL = configurationService.getProperty("iiif.transcriptions.label");
+
+        // We generate the transcriptions links iif the 2 configuration properties are set
+        if (TRANSCRIPTIONS_BUNDLE_NAME != null && TRANSCRIPTIONS_LABEL != null) addTranscriptions = true;
+    }
+
+    /**
+     * Method to generate a list of links to be included in the otherContent for the
+     * canvas. Will return an empty list if no links are found.
+     * 
+     * @param context       DSpace context
+     * @param item          The item generating the IIIF manifest
+     * @param bitstream     The bitstream generating the canvas
+     * @return              A list of links (can be emtpy, but wont be null)
+     */
+    public AnnotationList getCanvasTranscriptions(Context context, Item item, Bitstream bitstream, String linkUrl) {
+
+        // Only proceed if configuration is set
+        if ( !addTranscriptions || context == null || item == null || bitstream == null || linkUrl == null) return null;
+
+
+        // Check if we have the specified bundle, otherwise return null
+        Bundle transcriptionsBundle = null;
+        List<Bundle> bdls = item.getBundles();
+        for ( Bundle bdl: bdls ) {
+            if ( bdl.getName().equals(TRANSCRIPTIONS_BUNDLE_NAME) ) {
+                transcriptionsBundle = bdl;
+                break;
+            }
+        }
+        if ( transcriptionsBundle == null ) return null;
+
+        // Check if we have a bitstream with a correct name
+        String name = IIIFUtils.getRootName(bitstream.getName());
+        List<Bitstream> bts = transcriptionsBundle.getBitstreams();
+        for ( Bitstream bt: bts ) {
+            if ( IIIFUtils.getRootName(bt.getName()).startsWith(name)) {
+                // We have at least one bitstream, generate a link and stop searching
+                AnnotationList al = new AnnotationList(linkUrl);
+                al.setLabel(new PropertyValue(TRANSCRIPTIONS_LABEL));
+                return al;
+                //return new ExternalLinksGenerator(linkUrl)
+                //            .setType(AnnotationGenerator.TYPE)
+                //            .setLabel(TRANSCRIPTIONS_LABEL);
+            }            
+        }
+
+        // No bitstream found, return null
+        return null;
+    }
+}

--- a/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
+++ b/dspace/modules/additions/src/main/java/org/dspace/app/iiif/service/utils/IIIFUtils.java
@@ -1,0 +1,475 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.iiif.service.utils;
+
+import static org.dspace.iiif.util.IIIFSharedUtils.METADATA_IIIF_HEIGHT_QUALIFIER;
+import static org.dspace.iiif.util.IIIFSharedUtils.METADATA_IIIF_IMAGE_ELEMENT;
+import static org.dspace.iiif.util.IIIFSharedUtils.METADATA_IIIF_SCHEMA;
+import static org.dspace.iiif.util.IIIFSharedUtils.METADATA_IIIF_WIDTH_QUALIFIER;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import de.digitalcollections.iiif.model.sharedcanvas.Resource;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.iiif.model.ObjectMapperFactory;
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.dspace.iiif.IIIFApiQueryService;
+import org.dspace.iiif.util.IIIFSharedUtils;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IIIFUtils {
+
+    private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(IIIFUtils.class);
+
+    // The DSpace bundle for other content related to item.
+    protected static final String OTHER_CONTENT_BUNDLE = "OtherContent";
+
+    // The canvas position will be appended to this string.
+    private static final String CANVAS_PATH_BASE = "/canvas/c";
+
+    // metadata used to enable the iiif features on the item
+    public static final String METADATA_IIIF_ENABLED = "dspace.iiif.enabled";
+    // metadata used to enable the iiif search service on the item
+    public static final String METADATA_IIIF_SEARCH_ENABLED = "iiif.search.enabled";
+    // metadata used to override the title/name exposed as label to iiif client
+    public static final String METADATA_IIIF_LABEL = "iiif.label";
+    // metadata used to override the description/abstract exposed as label to iiif client
+    public static final String METADATA_IIIF_DESCRIPTION = "iiif.description";
+    // metadata used to set the position of the resource in the iiif manifest structure
+    public static final String METADATA_IIIF_TOC = "iiif.toc";
+    // metadata used to set the naming convention (prefix) used for all canvas that has not an explicit name
+    public static final String METADATA_IIIF_CANVAS_NAMING = "iiif.canvas.naming";
+    // metadata used to set the iiif viewing hint
+    public static final String METADATA_IIIF_VIEWING_HINT  = "iiif.viewing.hint";
+    // metadata used to set the width of the canvas that has not an explicit name
+    public static final String METADATA_IMAGE_WIDTH = METADATA_IIIF_SCHEMA + "." + METADATA_IIIF_IMAGE_ELEMENT
+        + "." + METADATA_IIIF_WIDTH_QUALIFIER;
+    // metadata used to set the height of the canvas that has not an explicit name
+    public static final String METADATA_IMAGE_HEIGHT = METADATA_IIIF_SCHEMA + "." + METADATA_IIIF_IMAGE_ELEMENT
+        + "." + METADATA_IIIF_HEIGHT_QUALIFIER;
+
+    // string used in the metadata toc as separator among the different levels
+    public static final String TOC_SEPARATOR = "|||";
+    // convenient constant to split a toc in its components
+    public static final String TOC_SEPARATOR_REGEX = "\\|\\|\\|";
+
+    // get module subclass.
+    protected SimpleModule iiifModule = ObjectMapperFactory.getIiifModule();
+    // Use the object mapper subclass.
+    protected ObjectMapper mapper = ObjectMapperFactory.getIiifObjectMapper();
+
+    @Autowired
+    protected BitstreamService bitstreamService;
+
+    @Autowired
+    ConfigurationService configurationService;
+
+    @Autowired
+    IIIFApiQueryService iiifApiQueryService;
+
+
+    public List<Bundle> getIIIFBundles(Item item) {
+        return IIIFSharedUtils.getIIIFBundles(item);
+    }
+
+    public boolean isIIIFEnabled(Item item) {
+        return IIIFSharedUtils.isIIIFEnabled(item);
+    }
+
+    /**
+     * Return all the bitstreams in the item to be used as IIIF resources
+     *
+     * @param context the DSpace Context
+     * @param item    the DSpace item
+     * @return a not null list of bitstreams to use as IIIF resources in the
+     *         manifest
+     */
+    public List<Bitstream> getIIIFBitstreams(Context context, Item item) {
+        List<Bitstream> bitstreams = new ArrayList<Bitstream>();
+        for (Bundle bnd : IIIFSharedUtils.getIIIFBundles(item)) {
+            bitstreams
+                    .addAll(getIIIFBitstreams(context, bnd));
+        }
+        return bitstreams;
+    }
+
+    /**
+     * Return all the bitstreams in the bundle to be used as IIIF resources
+     *
+     * @param context the DSpace Context
+     * @param bundle    the DSpace Bundle
+     * @return a not null list of bitstreams to use as IIIF resources in the
+     *         manifest
+     */
+    public List<Bitstream> getIIIFBitstreams(Context context, Bundle bundle) {
+        return bundle.getBitstreams().stream().filter(b -> isIIIFBitstream(context, b))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Utility method to check is a bitstream can be used as IIIF resources
+     *
+     * @param b the DSpace bitstream to check
+     * @return true if the bitstream can be used as IIIF resource
+     */
+    public boolean isIIIFBitstream(Context context, Bitstream b) {
+        return checkImageMimeType(getBitstreamMimeType(b, context)) && b.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_ENABLED))
+                .noneMatch(m -> m.getValue().equalsIgnoreCase("false") || m.getValue().equalsIgnoreCase("no"));
+    }
+
+    /**
+     * Returns the bitstream mime type
+     *
+     * @param bitstream DSpace bitstream
+     * @param context   DSpace context
+     * @return mime type
+     */
+    public String getBitstreamMimeType(Bitstream bitstream, Context context) {
+        try {
+            BitstreamFormat bitstreamFormat = bitstream.getFormat(context);
+            return bitstreamFormat.getMIMEType();
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    /**
+     * Checks to see if the item is searchable. Based on the
+     * {@link #METADATA_IIIF_SEARCH_ENABLED} metadata.
+     *
+     * @param item DSpace item
+     * @return true if the iiif search is enabled
+     */
+    public boolean isSearchable(Item item) {
+        return item.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals("iiif.search.enabled"))
+                .anyMatch(m -> m.getValue().equalsIgnoreCase("true")  ||
+                        m.getValue().equalsIgnoreCase("yes"));
+    }
+
+    /**
+     * Retrives a bitstream based on its position in the IIIF bundle.
+     *
+     * @param context        DSpace Context
+     * @param item           DSpace Item
+     * @param canvasPosition bitstream position
+     * @return bitstream or null if the specified canvasPosition doesn't exist in
+     *         the manifest
+     */
+    public Bitstream getBitstreamForCanvas(Context context, Item item, int canvasPosition) {
+        List<Bitstream> bitstreams = getIIIFBitstreams(context, item);
+        return bitstreams.size() > canvasPosition ? bitstreams.get(canvasPosition) : null;
+    }
+
+    /**
+     * Extracts canvas position from the URL input path.
+     * @param canvasId e.g. "c12"
+     * @return the position, e.g. 12
+     */
+    public int getCanvasId(String canvasId) {
+        return Integer.parseInt(canvasId.substring(1));
+    }
+
+    /**
+     * Returns the canvas path with position. The path
+     * returned is partial, not the fully qualified URI.
+     * @param position position of the bitstream in the DSpace bundle.
+     * @return partial canvas path.
+     */
+    public String getCanvasId(int position) {
+        return CANVAS_PATH_BASE + position;
+    }
+
+    /**
+     * Serializes the json response.
+     * @param resource to be serialized
+     * @return
+     */
+    public String asJson(Resource<?> resource) {
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.registerModule(iiifModule);
+        try {
+            return mapper.writeValueAsString(resource);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Tests for image mimetype. Presentation API 2.1.1 canvas supports images only.
+     * Other media types introduced in version 3.
+     * @param mimetype
+     * @return true if an image
+     */
+    private boolean checkImageMimeType(String mimetype) {
+        if (mimetype != null && mimetype.contains("image/")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Return all the bitstreams in the item to be used as annotations
+     *
+     * @param item    the DSpace item
+     * @return a not null list of bitstreams to use as IIIF resources in the
+     *         manifest
+     */
+    public List<Bitstream> getSeeAlsoBitstreams(Item item) {
+        List<Bitstream> seeAlsoBitstreams = new ArrayList<>();
+        List<Bundle> bundles = item.getBundles(OTHER_CONTENT_BUNDLE);
+        if (bundles.size() > 0) {
+            for (Bundle bundle : bundles) {
+                List<Bitstream> bitstreams = bundle.getBitstreams();
+                seeAlsoBitstreams.addAll(bitstreams);
+            }
+        }
+        return seeAlsoBitstreams;
+    }
+
+    /**
+     * Return the custom iiif label for the resource or the provided default if none
+     *
+     * @param dso          the dspace object to use as iiif resource
+     * @param defaultLabel the default label to return if none is specified in the
+     *                     metadata
+     * @return the iiif label for the dspace object
+     */
+    public String getIIIFLabel(DSpaceObject dso, String defaultLabel) {
+        return dso.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_LABEL))
+                .findFirst().map(m -> m.getValue()).orElse(defaultLabel);
+    }
+
+    /**
+     * Return the custom iiif description for the resource or the provided default if none
+     *
+     * @param dso          the dspace object to use as iiif resource
+     * @param defaultDescription the default description to return if none is specified in the
+     *                     metadata
+     * @return the iiif label for the dspace object
+     */
+    public String getIIIFDescription(DSpaceObject dso, String defaultDescription) {
+        return dso.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_DESCRIPTION))
+                .findFirst().map(m -> m.getValue()).orElse(defaultDescription);
+    }
+
+    /**
+     * Return the table of contents (toc) positions in the iiif structure where the
+     * resource appears. Please note that the same resource can belong to multiple
+     * ranges (i.e. a page that contains the last paragraph of a section and start
+     * the new section)
+     *
+     * @param bitstream    the dspace bitstream
+     * @param prefix a string to add to all the returned toc inherited from the
+     *               parent dspace object
+     * @return the iiif tocs for the dspace object
+     */
+    public List<String> getIIIFToCs(Bitstream bitstream, String prefix) {
+        List<String> tocs = bitstream.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_TOC))
+                .map(m -> StringUtils.isNotBlank(prefix) ? prefix + TOC_SEPARATOR + m.getValue() : m.getValue())
+                .collect(Collectors.toList());
+        if (tocs.size() == 0 && StringUtils.isNotBlank(prefix)) {
+            return List.of(prefix);
+        } else {
+            return tocs;
+        }
+    }
+
+    /**
+     * Retrieves image dimensions from the image server (IIIF Image API v.2.1.1).
+     * @param bitstream the bitstream DSO
+     * @return image dimensions
+     */
+    @Cacheable(key = "#bitstream.getID().toString()", cacheNames = "canvasdimensions")
+    public int[] getImageDimensions(Bitstream bitstream) {
+        return iiifApiQueryService.getImageDimensions(bitstream);
+    }
+
+    /**
+     * Test to see if the bitstream contains iiif image width metadata.
+     * @param bitstream the bitstream DSo
+     * @return true if width metadata was found
+     */
+    public boolean hasWidthMetadata(Bitstream bitstream) {
+        return bitstream.getMetadata().stream()
+                  .filter(m -> m.getMetadataField().toString('.').contentEquals("iiif.image.width"))
+                  .findFirst().map(m -> m != null).orElse(false);
+
+    }
+
+    /**
+     * Return the iiif toc for the specified bundle
+     * 
+     * @param bundle the dspace bundle
+     * @return the iiif toc for the specified bundle
+     */
+    public String getBundleIIIFToC(Bundle bundle) {
+        String label = bundle.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_LABEL))
+                .findFirst().map(m -> m.getValue()).orElse(getToCBundleLabel(bundle));
+        return bundle.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_TOC))
+                .findFirst().map(m -> m.getValue() + TOC_SEPARATOR + label).orElse(label);
+    }
+
+    /**
+     * Excludes bundles found in the iiif.exclude.toc.bundle list
+     *
+     * @param bundle    the dspace bundle
+     * @return  bundle name or null if bundle is excluded
+     */
+    private String getToCBundleLabel(Bundle bundle) {
+        String[] iiifAlternate = configurationService.getArrayProperty("iiif.exclude.toc.bundle");
+        if (Arrays.stream(iiifAlternate).anyMatch(x -> x.contentEquals(bundle.getName()))) {
+            return null;
+        }
+        return bundle.getName();
+    }
+
+    /**
+     * Return the iiif viewing hint for the item
+     * 
+     * @param item        the dspace item
+     * @param defaultHint the default hint to apply if nothing else is defined at
+     *                    the item leve
+     * @return the iiif viewing hint for the item
+     */
+    public String getIIIFViewingHint(Item item, String defaultHint) {
+        return item.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_VIEWING_HINT))
+                .findFirst().map(m -> m.getValue()).orElse(defaultHint);
+    }
+
+    /**
+     * Return the width for the canvas associated with the bitstream. If the
+     * bitstream doesn't provide directly the information it is retrieved from the
+     * bundle, item or default.
+     * 
+     * @param bitstream    the dspace bitstream used in the canvas
+     * @param bundle       the bundle the bitstream belong to
+     * @param item         the item the bitstream belong to
+     * @param defaultWidth the default width to apply if no other preferences are
+     *                     found
+     * @return the width in pixel for the canvas associated with the bitstream
+     */
+    public int getCanvasWidth(Bitstream bitstream, Bundle bundle, Item item, int defaultWidth) {
+        return getSizeFromMetadata(bitstream, METADATA_IMAGE_WIDTH,
+                    getSizeFromMetadata(bundle, METADATA_IMAGE_WIDTH,
+                        getSizeFromMetadata(item, METADATA_IMAGE_WIDTH, defaultWidth)));
+    }
+
+    /**
+     * Return the height for the canvas associated with the bitstream. If the
+     * bitstream doesn't provide directly the information it is retrieved from the
+     * bundle, item or default.
+     * 
+     * @param bitstream    the dspace bitstream used in the canvas
+     * @param bundle       the bundle the bitstream belong to
+     * @param item         the item the bitstream belong to
+     * @param defaultHeight the default width to apply if no other preferences are
+     *                     found
+     * @return the height in pixel for the canvas associated with the bitstream
+     */
+    public int getCanvasHeight(Bitstream bitstream, Bundle bundle, Item item, int defaultHeight) {
+        return getSizeFromMetadata(bitstream, METADATA_IMAGE_HEIGHT,
+                getSizeFromMetadata(bundle, METADATA_IMAGE_HEIGHT,
+                    getSizeFromMetadata(item, METADATA_IMAGE_HEIGHT, defaultHeight)));
+    }
+
+    /**
+     * Utility method to extract an integer from metadata value. The defaultValue is
+     * returned if there are not values for the specified metadata or the value is
+     * not a valid integer. Only the first metadata value if any is used
+     * 
+     * @param dso          the dspace object
+     * @param metadata     the metadata key (schema.element[.qualifier]
+     * @param defaultValue default to return if the metadata value is not an integer
+     * @return an integer from metadata value
+     */
+    private int getSizeFromMetadata(DSpaceObject dso, String metadata, int defaultValue) {
+        return dso.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(metadata))
+                .findFirst().map(m -> castToInt(m, defaultValue))
+                  .orElse(defaultValue);
+    }
+
+    /**
+     * Utility method to cast a metadata value to int. The defaultInt is returned if
+     * the metadata value is not a valid integer
+     * 
+     * @param m             the metadata value
+     * @param defaultInt default to return if the metadata value is not an
+     *                      integer
+     * @return an int corresponding to the metadata value
+     */
+    private int castToInt(MetadataValue m, int defaultInt) {
+        try {
+            return Integer.parseInt(m.getValue());
+        } catch (NumberFormatException e) {
+            log.error("Error parsing " + m.getMetadataField().toString('.') + " of " + m.getDSpaceObject().getID()
+                    + " the value " + m.getValue() + " is not an integer. Returning the default.");
+        }
+        return defaultInt;
+    }
+
+    /**
+     * Return the prefix to use to generate canvas name for canvas that has no an
+     * explicit IIIF label
+     * 
+     * @param item          the DSpace Item
+     * @param defaultNaming a default to return if the item has not a custom value
+     * @return the prefix to use to generate canvas name for canvas that has no an
+     *         explicit IIIF label
+     */
+    public String getCanvasNaming(Item item, String defaultNaming) {
+        return item.getMetadata().stream()
+                .filter(m -> m.getMetadataField().toString('.').contentEquals(METADATA_IIIF_CANVAS_NAMING))
+                .findFirst().map(m -> m.getValue()).orElse(defaultNaming);
+    }
+
+    /**
+     * Check a String (filename) and returns the portion before the last occurrence of "."
+     * @param name  The String to check
+     * @return  The portion before ".", or the string itself if not found
+     */
+    public static String getRootName(String name) {
+        String root = name;
+        int dotPos = root.lastIndexOf(".");
+        if (dotPos > 0) {
+            root = name.substring(0, dotPos);
+        }
+        return root;
+    }
+
+
+}


### PR DESCRIPTION
Pour tester, voici ce qu'il faut faire:

1. Pour un item IIIF, ajouter un bundle TRANSCRIPTIONS
2. Dans ce bundle, déposer un ou des fichiers de type texte (.txt) ou HTML (.html), donc le nom (sans extension) début par le nom (sans extension) d'un bitstream (image)

Dans le manifest, il devrait y avoir un "otherContent" pour le Canvas de ce bitstream. Mirador devrait le présenter comme des annotations pour l'image.
