### PR TITLE
Désactivation du plugin Tika (extraction de texte)

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -448,7 +448,7 @@ useProxies = true
 # perform automated format conversions
 
 #Names of the enabled MediaFilter or FormatFilter plugins
-filter.plugins = Text Extractor
+#filter.plugins = Text Extractor
 filter.plugins = JPEG Thumbnail
 filter.plugins = PDFBox JPEG Thumbnail
 


### PR DESCRIPTION
Désactivation du plugin Tika (extraction de texte à partir de filter-media). L’extraction des textes sera effectuée automatiquement selon la langue dans un autre processus.