### PR TITLE
Ajout du fichier de libellés personnalisés pour les métadonnées de Mirador

### DIFF
--- a/dspace/modules/server/src/main/resources/Messages.properties
+++ b/dspace/modules/server/src/main/resources/Messages.properties
@@ -1,0 +1,2 @@
+
+metadata.dc.language.iso			= Language


### PR DESCRIPTION
Ajout du fichier de libellés personnalisés pour les métadonnées de Mirador.