### PR TITLE
Modification des métadonnées du manifest IIIF

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -91,9 +91,18 @@ iiif.logo.image = ${dspace.ui.url}/assets/collspec/images/logo-bib.png
 # Plusieurs autres configurations possibles, voir modules/iiif.cfg
 
 iiif.metadata.item = dc.title
-iiif.metadata.item = dc.date.issued
+iiif.metadata.item = dc.title.alternative
+iiif.metadata.item = dc.identifier.*
 iiif.metadata.item = dc.contributor.*
+iiif.metadata.item = dc.publisher
+iiif.metadata.item = dc.date.issued
+iiif.metadata.item = dc.type
+iiif.metadata.item = dc.subject
 iiif.metadata.item = dc.description.abstract
+iiif.metadata.item = dc.description
+iiif.metadata.item = dc.format.extent
+iiif.metadata.item = dc.source
+iiif.metadata.item = dc.rights
 iiif.metadata.item = dc.language.iso
 
 # Pour ajouter des seeAlso à un item depuis un bundle spécifique

--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -39,10 +39,10 @@ iiif.cors.allow-credentials = false
 
 # metadata to include at the resource level in the manifest
 # labels are set in the Messages.properties i18n file
-iiif.metadata.item = dc.title
-iiif.metadata.item = dc.date.issued
-iiif.metadata.item = dc.contributor.*
-iiif.metadata.item = dc.description.abstract
+#iiif.metadata.item = dc.title
+#iiif.metadata.item = dc.date.issued
+#iiif.metadata.item = dc.contributor.*
+#iiif.metadata.item = dc.description.abstract
 
 # metadata to be added to the canvas from the bitstream, labels are set in 
 # the Messages.properties i18n file. It is possible to include the technical
@@ -52,14 +52,14 @@ iiif.metadata.item = dc.description.abstract
 # @mimemtype@ to include the mimetype associated with the bitstream format in the registry
 # @checksum@ to include the computed checksum for the file and the used algorithm
 # @bytes@ to include the size of the images in bytes
-iiif.metadata.bitstream = dc.title
-iiif.metadata.bitstream = dc.description
-iiif.metadata.bitstream = @format@
-iiif.metadata.bitstream = @mimetype@
-iiif.metadata.bitstream = iiif.image.width
-iiif.metadata.bitstream = iiif.image.height
-iiif.metadata.bitstream = @bytes@
-iiif.metadata.bitstream = @checksum@
+#iiif.metadata.bitstream = dc.title
+#iiif.metadata.bitstream = dc.description
+#iiif.metadata.bitstream = @format@
+#iiif.metadata.bitstream = @mimetype@
+#iiif.metadata.bitstream = iiif.image.width
+#iiif.metadata.bitstream = iiif.image.height
+#iiif.metadata.bitstream = @bytes@
+#iiif.metadata.bitstream = @checksum@
 
 # the metadata to use to provide machine readable information about the resource right usage
 iiif.license.uri = dc.rights.uri

--- a/dspace/modules/server/src/main/resources/Messages.properties
+++ b/dspace/modules/server/src/main/resources/Messages.properties
@@ -1,2 +1,5 @@
 
 metadata.dc.language.iso			= Language
+metadata.dc.type                    = Type
+metadata.dc.format.extent           = Extent
+metadata.dc.source                  = Source


### PR DESCRIPTION
Modification des métadonnées du manifest IIIF.
Suppression des métadonnées techniques du Canvas dans le manifest IIIF.