### PR TITLE
Déplacement du paramètre  iiif.image.server

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -68,7 +68,8 @@ registry.metadata.load = collspec-types.xml
 
 iiif.enabled = true
 event.dispatcher.default.consumers = versioning, discovery, eperson, qaeventsdelete, ldnmessage, iiif
-iiif.image.server = https://cantaloupe.bib.umontreal.ca/iiif/2/
+##Juste en production
+#iiif.image.server = https://cantaloupe.bib.umontreal.ca/iiif/2/
 
 # Pour la recherche dans les documents avec OCR, ajuster
 # dans local.local.cfg si ce n'est pas le core "ocr"


### PR DESCRIPTION
Déplacer ce paramètre en production dans le fichier `local.local.cfg`. Pas nécessaire pour l’instance locale.
