### PR TITLE
Enlever l'affichage de dc.title dans Mirador (doublon)

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -100,7 +100,7 @@ iiif.logo.image = ${dspace.ui.url}/assets/collspec/images/logo-bib.png
 
 # Plusieurs autres configurations possibles, voir modules/iiif.cfg
 
-iiif.metadata.item = dc.title
+# iiif.metadata.item = dc.title
 iiif.metadata.item = dc.title.alternative
 iiif.metadata.item = dcterms.title
 iiif.metadata.item = dcterms.alternative


### PR DESCRIPTION
Selon le mapping, on utilise dcterms.title pour les titres, mais on conserve également la même valeur dans dc.title pour d'autres dépendences.